### PR TITLE
login test

### DIFF
--- a/client/src/components/DropdownMenu/MeunItem.tsx
+++ b/client/src/components/DropdownMenu/MeunItem.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { ReactComponent as AddButton } from "../../assets/images/Add.svg";
-import myImage from "/Users/dahae/Desktop/GitHub/seb45_main_003/client/src/assets/images/Img1.png";
+import myImage from "../../assets/images/Img1.png";
 import { Link } from "react-router-dom";
 
 const ItemContainer = styled.div`

--- a/client/src/components/login/LoginForm.tsx
+++ b/client/src/components/login/LoginForm.tsx
@@ -38,7 +38,6 @@ const LogInForm = (): JSX.Element => {
       const response = await axios.post(`${process.env.REACT_APP_API_URL}/members/login`, body);
       if (response.status === 200) {
         const headers = response.headers;
-        console.log(headers);
         const accessToken = headers["authorization"];
         const refreshToken = headers["refresh"];
         console.log(`access:${accessToken}`, `refresh:${refreshToken}`);

--- a/client/src/components/login/SignupForm.tsx
+++ b/client/src/components/login/SignupForm.tsx
@@ -47,6 +47,15 @@ const StyledSignupForm = styled.form`
   #confirmcode {
     flex: 1 0 21.875rem;
   }
+  .errormessage {
+    color: #f44336;
+  }
+  .successmessage {
+    color: #33a754;
+  }
+  .errorInput {
+    border-color: #f44336;
+  }
 `;
 const StyledModal = styled.div`
   width: 22.0625rem;
@@ -139,11 +148,12 @@ const SignupForm = (): JSX.Element => {
           id="name"
           type="text"
           placeholder="성함"
+          className={errors.name ? "errorInput" : "input"}
           {...register("name", {
             required: "성함을 작성해주세요.",
           })}
         />
-        {errors.name && <div>{errors.name?.message}</div>}
+        {errors.name && <div className="errormessage">{errors.name?.message}</div>}
         <label htmlFor="email">Email</label>
         <div className="withButton">
           <input
@@ -151,6 +161,7 @@ const SignupForm = (): JSX.Element => {
             type="email"
             placeholder="Email"
             readOnly={success.confirm}
+            className={errors.email ? "errorInput" : "input"}
             {...register("email", {
               required: "이메일을 작성해주세요.",
               pattern: {
@@ -167,8 +178,8 @@ const SignupForm = (): JSX.Element => {
             onClick={() => reqConfirmCode(getValues("email"))}
           />
         </div>
-        {errors.email && <div>{errors.email?.message}</div>}
-        {success.req && <div>인증코드를 전송했습니다.</div>}
+        {errors.email && <div className="errormessage">{errors.email?.message}</div>}
+        {success.req && <div className="successmessage">인증코드를 전송했습니다.</div>}
         <label htmlFor="confirmcode">인증코드</label>
         <div className="withButton">
           <input
@@ -176,6 +187,7 @@ const SignupForm = (): JSX.Element => {
             type="text"
             placeholder="인증코드"
             readOnly={success.confirm}
+            className={errors.confirmcode ? "errorInput" : "input"}
             {...register("confirmcode", {
               required: "이메일로 전송된 인증코드를 입력해주세요.",
             })}
@@ -187,13 +199,14 @@ const SignupForm = (): JSX.Element => {
             onClick={() => testConfirmCode(getValues())}
           />
         </div>
-        {errors.confirmcode && <div>{errors.confirmcode?.message}</div>}
-        {success.confirm && <div>인증되었습니다.</div>}
+        {errors.confirmcode && <div className="errormessage">{errors.confirmcode?.message}</div>}
+        {success.confirm && <div className="successmessage">인증되었습니다.</div>}
         <label htmlFor="password">비밀번호</label>
         <input
           id="password"
           type="password"
           placeholder="비밀번호는 8자리 이상의 숫자, 특수문자, 영문을 조합해주세요."
+          className={errors.password ? "errorInput" : "input"}
           {...register("password", {
             required: "비밀번호를 입력해주세요.",
             minLength: {
@@ -206,12 +219,13 @@ const SignupForm = (): JSX.Element => {
             },
           })}
         />
-        {errors.password && <div>{errors.password?.message}</div>}
+        {errors.password && <div className="errormessage">{errors.password?.message}</div>}
         <label htmlFor="chekcpassword">비밀번호 확인</label>
         <input
           id="checkpassword"
           type="password"
           placeholder="비밀번호 확인"
+          className={errors.checkpassword ? "errorInput" : "input"}
           {...register("checkpassword", {
             required: "비밀번호를 확인해주세요.",
             validate: (value: string) => {
@@ -221,12 +235,15 @@ const SignupForm = (): JSX.Element => {
             },
           })}
         />
-        {errors.checkpassword && <div>{errors.checkpassword?.message}</div>}
+        {errors.checkpassword && (
+          <div className="errormessage">{errors.checkpassword?.message}</div>
+        )}
         <label htmlFor="phone">핸드폰 번호</label>
         <input
           id="phone"
           type="text"
           placeholder="-를 제외한 번호를 입력해주세요."
+          className={errors.phone ? "errorInput" : "input"}
           {...register("phone", {
             required: "핸드폰 번호를 작성해주세요.",
             pattern: {
@@ -235,7 +252,7 @@ const SignupForm = (): JSX.Element => {
             },
           })}
         />
-        {errors.phone && <div>{errors.phone?.message}</div>}
+        {errors.phone && <div className="errormessage">{errors.phone?.message}</div>}
         <Button type={"submit"} disabled={isSubmitting} text={"회원가입"} />
       </StyledSignupForm>
       <Modal isOpen={isOpen} closeModal={closeModal} toggleModal={toggleModal}>

--- a/client/src/components/login/SignupForm.tsx
+++ b/client/src/components/login/SignupForm.tsx
@@ -136,10 +136,11 @@ const SignupForm = (): JSX.Element => {
   };
 
   const [loginPageForm, setloginPageForm] = useRecoilState(toSignup);
+  //로그인 컴포넌트로 변환하는 함수
   const changeform = () => {
     setloginPageForm(!loginPageForm);
   };
-  //Todo: 이메일이 인증되면 이메일을 바꿀 수 없게 email input 비활성화, buttonText를 buttontext로 수정
+
   return (
     <>
       <StyledSignupForm onSubmit={handleSubmit(submitSignup)}>

--- a/client/src/components/login/SignupForm.tsx
+++ b/client/src/components/login/SignupForm.tsx
@@ -1,7 +1,11 @@
 import axios from "axios";
 import { useForm } from "react-hook-form";
-import Button from "../common/Button";
 import { styled } from "styled-components";
+import { useState } from "react";
+import { useModal } from "../../hooks/useModal";
+import Button from "../common/Button";
+import Modal from "../common/Modal";
+
 //폼에서 사용하는 데이터
 interface SignupForm {
   name: string;
@@ -42,6 +46,13 @@ const StyledSignupForm = styled.form`
     flex: 1 0 21.875rem;
   }
 `;
+const StyledModal = styled.div`
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+`;
 
 const SignupForm = (): JSX.Element => {
   const {
@@ -51,133 +62,164 @@ const SignupForm = (): JSX.Element => {
     setError,
     getValues,
   } = useForm<SignupForm>();
+  const { toggleModal, isOpen, closeModal } = useModal();
+  const [success, setSuccess] = useState({
+    req: false,
+    confirm: false,
+  });
   //폼에 작성된 데이터들을 서버로 전송하는 함수
   const submitSignup = async (data: SignupData) => {
-    const response = await axios.post(`${process.env.REACT_APP_API_URL}/members`, data);
-    if (!response) {
-      setError("formError", {
-        message: "잘못 작성된 부분이 있습니다.",
-      });
+    toggleModal();
+    try {
+      const response = await axios.post(`${process.env.REACT_APP_API_URL}/members`, data);
+      if (response.status === 201) {
+        toggleModal();
+      } else {
+        setError("formError", {
+          message: "잘못 작성된 부분이 있습니다.",
+        });
+      }
+    } catch (error) {
+      console.log(`Error: ${error}`);
     }
   };
   //인증코드를 보내달라는 요청 함수
   const reqConfirmCode = async (data: string) => {
-    await axios.post(`${process.env.REACT_APP_API_URL}/email/auth/send`, {
+    //새로고침 방지
+    event?.preventDefault();
+    const response = await axios.post(`${process.env.REACT_APP_API_URL}/email/auth/send`, {
       email: data,
     });
+    if (response.status === 200) {
+      console.log("succsess");
+      setSuccess({ ...success, req: true });
+    }
   };
   //사용자가 작성한 인증코드를 서버에서 검증하게 보내주는 함수
   const testConfirmCode = async (data: SignupForm) => {
-    await axios.get(`${process.env.REACT_APP_API_URL}/email/auth`, {
-      data: {
-        email: data.email,
-        authCode: data.confirmcode,
-      },
+    //새로고침 방지
+    event?.preventDefault();
+    const response = await axios.post(`${process.env.REACT_APP_API_URL}/email/auth`, {
+      email: data.email,
+      authCode: data.confirmcode,
     });
+    if (response.status === 200) {
+      console.log("succsess");
+      setSuccess({ ...success, confirm: true });
+    }
   };
   //Todo: 이메일이 인증되면 이메일을 바꿀 수 없게 email input 비활성화, buttonText를 buttontext로 수정
   return (
-    <StyledSignupForm onSubmit={handleSubmit(submitSignup)}>
-      <label htmlFor="name">성함</label>
-      <input
-        id="name"
-        type="text"
-        placeholder="성함"
-        {...register("name", {
-          required: "성함을 작성해주세요.",
-        })}
-      />
-      {errors.name && <div>{errors.name?.message}</div>}
-      <label htmlFor="email">Email</label>
-      <div className="withButton">
+    <>
+      <StyledSignupForm onSubmit={handleSubmit(submitSignup)}>
+        <label htmlFor="name">성함</label>
         <input
-          id="email"
-          type="email"
-          placeholder="Email"
-          {...register("email", {
-            required: "이메일을 작성해주세요.",
+          id="name"
+          type="text"
+          placeholder="성함"
+          {...register("name", {
+            required: "성함을 작성해주세요.",
+          })}
+        />
+        {errors.name && <div>{errors.name?.message}</div>}
+        <label htmlFor="email">Email</label>
+        <div className="withButton">
+          <input
+            id="email"
+            type="email"
+            placeholder="Email"
+            readOnly={success.req}
+            {...register("email", {
+              required: "이메일을 작성해주세요.",
+              pattern: {
+                value:
+                  /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
+                message: "이메일 형식에 맞게 작성해주세요.",
+              },
+            })}
+          />
+          <Button
+            type={"button"}
+            disabled={false}
+            text={"인증요청"}
+            onClick={() => reqConfirmCode(getValues("email"))}
+          />
+        </div>
+        {errors.email && <div>{errors.email?.message}</div>}
+        {success.req && <div>인증코드를 전송했습니다.</div>}
+        <label htmlFor="confirmcode">인증코드</label>
+        <div className="withButton">
+          <input
+            id="confirmcode"
+            type="text"
+            placeholder="인증코드"
+            readOnly={success.confirm}
+            {...register("confirmcode", {
+              required: "이메일로 전송된 인증코드를 입력해주세요.",
+            })}
+          />
+          <Button
+            type={"button"}
+            disabled={false}
+            text={"인증하기"}
+            onClick={() => testConfirmCode(getValues())}
+          />
+        </div>
+        {errors.confirmcode && <div>{errors.confirmcode?.message}</div>}
+        {success.confirm && <div>인증되었습니다.</div>}
+        <label htmlFor="password">비밀번호</label>
+        <input
+          id="password"
+          type="password"
+          placeholder="비밀번호는 8자리 이상의 숫자, 특수문자, 영문을 조합해주세요."
+          {...register("password", {
+            required: "비밀번호를 입력해주세요.",
+            minLength: {
+              value: 8,
+              message: "8자리 이상의 비밀번호를 사용해주세요.",
+            },
             pattern: {
-              value:
-                /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
-              message: "이메일 형식에 맞게 작성해주세요.",
+              value: /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9])/,
+              message: "비밀번호는 숫자, 특수문자, 영문을 조합해주세요.",
             },
           })}
         />
-        <Button
-          type={"button"}
-          disabled={false}
-          text={"인증요청"}
-          onClick={() => reqConfirmCode(getValues("email"))}
-        />
-      </div>
-      {errors.email && <div>{errors.email?.message}</div>}
-      <label htmlFor="confirmcode">인증코드</label>
-      <div className="withButton">
+        {errors.password && <div>{errors.password?.message}</div>}
+        <label htmlFor="chekcpassword">비밀번호 확인</label>
         <input
-          id="confirmcode"
-          type="text"
-          placeholder="인증코드"
-          {...register("confirmcode", {
-            required: "이메일로 전송된 인증코드를 입력해주세요.",
+          id="checkpassword"
+          type="password"
+          placeholder="비밀번호 확인"
+          {...register("checkpassword", {
+            required: "비밀번호를 확인해주세요.",
+            validate: (value: string) => {
+              if (value !== getValues("password")) {
+                return "비밀번호가 일치하지 않습니다.";
+              }
+            },
           })}
         />
-        <Button
-          type={"button"}
-          disabled={false}
-          text={"인증하기"}
-          onClick={() => testConfirmCode(getValues())}
+        {errors.checkpassword && <div>{errors.checkpassword?.message}</div>}
+        <label htmlFor="phone">핸드폰 번호</label>
+        <input
+          id="phone"
+          type="text"
+          placeholder="-를 제외한 번호를 입력해주세요."
+          {...register("phone", {
+            required: "핸드폰 번호를 작성해주세요.",
+            pattern: {
+              value: /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/,
+              message: "휴대폰 번호로 적어주세요.",
+            },
+          })}
         />
-      </div>
-      {errors.confirmcode && <div>{errors.confirmcode?.message}</div>}
-      <label htmlFor="password">비밀번호</label>
-      <input
-        id="password"
-        type="password"
-        placeholder="비밀번호는 8자리 이상의 숫자, 특수문자, 영문을 조합해주세요."
-        {...register("password", {
-          required: "비밀번호를 입력해주세요.",
-          minLength: {
-            value: 8,
-            message: "8자리 이상의 비밀번호를 사용해주세요.",
-          },
-          pattern: {
-            value: /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9])/,
-            message: "비밀번호는 숫자, 특수문자, 영문을 조합해주세요.",
-          },
-        })}
-      />
-      {errors.password && <div>{errors.password?.message}</div>}
-      <label htmlFor="chekcpassword">비밀번호 확인</label>
-      <input
-        id="checkpassword"
-        type="password"
-        placeholder="비밀번호 확인"
-        {...register("checkpassword", {
-          required: "비밀번호를 확인해주세요.",
-          validate: (value: string) => {
-            if (value !== getValues("password")) {
-              return "비밀번호가 일치하지 않습니다.";
-            }
-          },
-        })}
-      />
-      {errors.checkpassword && <div>{errors.checkpassword?.message}</div>}
-      <label htmlFor="phone">핸드폰 번호</label>
-      <input
-        id="phone"
-        type="text"
-        placeholder="-를 제외한 번호를 입력해주세요."
-        {...register("phone", {
-          required: "핸드폰 번호를 작성해주세요.",
-          pattern: {
-            value: /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/,
-            message: "휴대폰 번호로 적어주세요.",
-          },
-        })}
-      />
-      {errors.phone && <div>{errors.phone?.message}</div>}
-      <Button type={"submit"} disabled={isSubmitting} text={"회원가입"} />
-    </StyledSignupForm>
+        {errors.phone && <div>{errors.phone?.message}</div>}
+        <Button type={"submit"} disabled={isSubmitting} text={"회원가입"} />
+      </StyledSignupForm>
+      <Modal isOpen={isOpen} closeModal={closeModal} toggleModal={toggleModal}>
+        <StyledModal>어디?</StyledModal>
+      </Modal>
+    </>
   );
 };
 

--- a/client/src/components/login/SignupForm.tsx
+++ b/client/src/components/login/SignupForm.tsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import { styled } from "styled-components";
 import { useState } from "react";
 import { useModal } from "../../hooks/useModal";
+import { useRecoilState } from "recoil";
+import { toSignup } from "../../atoms/atoms";
 import Button from "../common/Button";
 import Modal from "../common/Modal";
 
@@ -47,11 +49,25 @@ const StyledSignupForm = styled.form`
   }
 `;
 const StyledModal = styled.div`
-  padding: 1rem;
+  width: 22.0625rem;
+  height: 11.25rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 2.3125rem;
+  .modalTextContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
+  .modalButtonContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-end;
+  }
 `;
 
 const SignupForm = (): JSX.Element => {
@@ -69,7 +85,6 @@ const SignupForm = (): JSX.Element => {
   });
   //폼에 작성된 데이터들을 서버로 전송하는 함수
   const submitSignup = async (data: SignupData) => {
-    toggleModal();
     try {
       const response = await axios.post(`${process.env.REACT_APP_API_URL}/members`, data);
       if (response.status === 201) {
@@ -109,6 +124,11 @@ const SignupForm = (): JSX.Element => {
       //인증성공시 인증코드 작성란과 이메일 작성란을 비활성화
       setSuccess({ ...success, confirm: true });
     }
+  };
+
+  const [loginPageForm, setloginPageForm] = useRecoilState(toSignup);
+  const changeform = () => {
+    setloginPageForm(!loginPageForm);
   };
   //Todo: 이메일이 인증되면 이메일을 바꿀 수 없게 email input 비활성화, buttonText를 buttontext로 수정
   return (
@@ -219,7 +239,14 @@ const SignupForm = (): JSX.Element => {
         <Button type={"submit"} disabled={isSubmitting} text={"회원가입"} />
       </StyledSignupForm>
       <Modal isOpen={isOpen} closeModal={closeModal} toggleModal={toggleModal}>
-        <StyledModal>어디?</StyledModal>
+        <StyledModal>
+          <div className="modalTextContainer">
+            <p>회원가입 되셨습니다!</p>
+          </div>
+          <div className="modalButtonContainer">
+            <Button type={"button"} disabled={false} text={"확인"} onClick={() => changeform()} />
+          </div>
+        </StyledModal>
       </Modal>
     </>
   );

--- a/client/src/components/login/SignupForm.tsx
+++ b/client/src/components/login/SignupForm.tsx
@@ -92,6 +92,7 @@ const SignupForm = (): JSX.Element => {
     });
     if (response.status === 200) {
       console.log("succsess");
+      //인증코드 전송시 안내문 제공
       setSuccess({ ...success, req: true });
     }
   };
@@ -105,6 +106,7 @@ const SignupForm = (): JSX.Element => {
     });
     if (response.status === 200) {
       console.log("succsess");
+      //인증성공시 인증코드 작성란과 이메일 작성란을 비활성화
       setSuccess({ ...success, confirm: true });
     }
   };
@@ -128,7 +130,7 @@ const SignupForm = (): JSX.Element => {
             id="email"
             type="email"
             placeholder="Email"
-            readOnly={success.req}
+            readOnly={success.confirm}
             {...register("email", {
               required: "이메일을 작성해주세요.",
               pattern: {

--- a/client/src/pages/LogIn.tsx
+++ b/client/src/pages/LogIn.tsx
@@ -39,6 +39,14 @@ const PageContentContainer = styled.div`
     }
   }
 
+  #socialButtonContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
   .labelContainer {
     display: flex;
     justify-content: center;
@@ -72,29 +80,32 @@ const LogIn = (): JSX.Element => {
     <BackgroundContainer>
       {loginPageForm ? (
         <PageContentContainer>
-          <h1>로그인</h1>
+          <h2>로그인</h2>
           <LogInForm />
           <div className="labelContainer">
-            <label htmlFor="socialButton" className="socialLabel">
+            <label htmlFor="socialButtonContainer" className="socialLabel">
               소셜 로그인
             </label>
           </div>
-          <fieldset id="socialButton"></fieldset>
+          <div id="socialButtonContainer">
+            <Button type="button" text={"구글 로그인"} />
+            <Button type="button" text={"카카오 로그인"} />
+          </div>
           <div className="bottomContainer">
             <div className="guide">
               <div className="guideTitle">서비스를 처음 방문하셨나요?</div>
-              <Button disabled={false} type={"button"} text={"회원가입"} onClick={changeform} />
+              <Button type={"button"} text={"회원가입"} onClick={changeform} />
             </div>
           </div>
         </PageContentContainer>
       ) : (
         <PageContentContainer>
-          <h1>회원가입</h1>
+          <h2>회원가입</h2>
           <SignupForm />
           <div className="bottomContainer">
             <div className="guide">
               <div className="guideTitle">이미 계정이 있으신가요?</div>
-              <Button disabled={false} type={"button"} text={"로그인"} onClick={changeform} />
+              <Button type={"button"} text={"로그인"} onClick={changeform} />
             </div>
           </div>
         </PageContentContainer>

--- a/client/src/pages/LogIn.tsx
+++ b/client/src/pages/LogIn.tsx
@@ -20,12 +20,23 @@ const PageContentContainer = styled.div`
   align-items: stretch;
   gap: 1.5rem;
 
-  .guide {
+  .bottomContainer {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.75rem;
+
+    .guide {
+      width: 224px;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: center;
+      gap: 0.75rem;
+      .guideTitle {
+        text-align: center;
+      }
+    }
   }
 
   .labelContainer {
@@ -69,18 +80,22 @@ const LogIn = (): JSX.Element => {
             </label>
           </div>
           <fieldset id="socialButton"></fieldset>
-          <div className="guide">
-            <div>서비스를 처음 방문하셨나요?</div>
-            <Button disabled={false} type={"button"} text={"회원가입"} onClick={changeform} />
+          <div className="bottomContainer">
+            <div className="guide">
+              <div className="guideTitle">서비스를 처음 방문하셨나요?</div>
+              <Button disabled={false} type={"button"} text={"회원가입"} onClick={changeform} />
+            </div>
           </div>
         </PageContentContainer>
       ) : (
         <PageContentContainer>
           <h1>회원가입</h1>
           <SignupForm />
-          <div className="guide">
-            <div>이미 계정이 있으신가요?</div>
-            <Button disabled={false} type={"button"} text={"로그인"} onClick={changeform} />
+          <div className="bottomContainer">
+            <div className="guide">
+              <div className="guideTitle">이미 계정이 있으신가요?</div>
+              <Button disabled={false} type={"button"} text={"로그인"} onClick={changeform} />
+            </div>
           </div>
         </PageContentContainer>
       )}

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const MainTitle = styled.text`
+const MainTitle = styled.div`
   color: #222;
   text-align: center;
   font-family: Pretendard Variable;

--- a/client/src/styles/global.ts
+++ b/client/src/styles/global.ts
@@ -55,7 +55,13 @@ ul {
   list-style: none;
 }
 button,
-input,
+input {
+  height: 2.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  border-radius: 6px;
+  border: .0625rem solid #e0e0e0;
+}
 select {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
서버연결후 테스트 완료
- 인증완료 후 인풋을 잠그게 바꾸었기 때문에 추가 테스트 필요
- 회원가입성공시 모달창 열리고 확인버튼 누르면 로그인컴포넌트로 변환
- 액세스토큰과 리프레쉬토큰은 로컬스토리지에 각각 accessToken, refreshToken이라는 이름으로 저장 
- accessToken의 경우 bearer가 붙어있으므로 그대로 헤더에 담아 사용하면 됩니다.
- 글로벌 스타일 설정에 input 스타일 피그마와 같게 조정
TODO
- 로그인상태일때 로그인및 회원가입페이지로 어떤방법으로도 접근 못하게 만들어야 함(방법고민중)
- 회원가입 성공모달은  모달이라 외곽클릭시 그냥 모달창만 닫혀서 어떻게 처리할지 고민중
- input만 스타일 조정했는데 버튼에도 스타일이 적용되고 있어 고쳐야 합니다.,;;