### PR TITLE
✨ 메세지 알림 총수량 표시

### DIFF
--- a/client/src/components/chatting/chatinList/ChattingListData.tsx
+++ b/client/src/components/chatting/chatinList/ChattingListData.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, ChangeEvent } from "react";
 import axios from "axios";
 import { useRecoilState, useRecoilValue, RecoilState } from "recoil";
 import { loginState } from "../../../atoms/atoms"; // 필요한 Recoil 상태를 가져옵니다.
-import { chatListState } from "../recoil/chatState";
+import { chatListState, totalUnreadMessagesState } from "../recoil/chatState";
 import styled from "styled-components";
 import { currentChatRoomIdState } from "../recoil/chatState";
 import FormatTimeOrDate from "../hook/FormatTimeOrDate";
@@ -186,14 +186,13 @@ const Box = styled.div`
 
 const ChattingListData: React.FC = () => {
   // const isConnected = useRecoilValue(webSocketConnectionState); // 웹소켓 연결 상태
-
   const [chatList, setChatList] = useRecoilState(chatListState as RecoilState<ChatList[]>);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [, setCurrentChatRoomId] = useRecoilState(currentChatRoomIdState);
   const isLoggedIn = useRecoilValue(loginState);
   const navigate = useNavigate();
   // State for storing the total number of unread messages.
-  const [totalUnreadMessages, setTotalUnreadMessages] = useState(0);
+  const [totalUnreadMessages, setTotalUnreadMessages] = useRecoilState(totalUnreadMessagesState);
 
   // 모든 알림 갯수
   useEffect(() => {

--- a/client/src/components/chatting/recoil/chatState.ts
+++ b/client/src/components/chatting/recoil/chatState.ts
@@ -68,3 +68,8 @@ export const webSocketConnectionState = atom({
   key: "webSocketConnection",
   default: false, // 초기값은 연결되지 않은 상태
 });
+
+export const totalUnreadMessagesState = atom({
+  key: "totalUnreadMessagesState", // unique ID (with respect to other atoms/selectors)
+  default: 0, // default value (aka initial value)
+});

--- a/client/src/components/header/LoginProfile.tsx
+++ b/client/src/components/header/LoginProfile.tsx
@@ -4,7 +4,8 @@ import { Link } from "react-router-dom";
 import PersonIcon from "@mui/icons-material/Person";
 import ChatBubbleIcon from "@mui/icons-material/ChatBubble";
 import React from "react";
-// import { red } from "@mui/material/colors";
+import { totalUnreadMessagesState } from "../chatting/recoil/chatState";
+import { useRecoilValue } from "recoil";
 
 const ItemBox = styled.div`
   align-self: stretch;
@@ -50,20 +51,6 @@ interface ProfileListProps {
   linkTo: string;
 }
 
-// interface ChildComponentProps {
-//   totalUnreadMessages: number;
-// }
-
-// export const UnreadMessages: React.FC<ChildComponentProps> = ({ totalUnreadMessages }) => {
-//   return (
-//     <div>
-//       <h2>Total Unread Messages in Child: {totalUnreadMessages}</h2>
-//     </div>
-//   );
-// };
-
-// console.log = UnreadMessages;
-
 const ProfileList: React.FC<ProfileListProps> = ({ icon, text, count, linkTo }) => {
   return (
     <>
@@ -80,6 +67,8 @@ const ProfileList: React.FC<ProfileListProps> = ({ icon, text, count, linkTo }) 
 
 // 사용 예시
 const ProfileButton = () => {
+  const totalUnreadMessages = useRecoilValue(totalUnreadMessagesState);
+
   return (
     <Container>
       <ProfileList
@@ -91,7 +80,7 @@ const ProfileButton = () => {
       <ProfileList
         icon={<ChatBubbleIcon />} // 아이콘 컴포넌트
         text="Messages" // 텍스트
-        count={10} // 카운트
+        count={totalUnreadMessages} // 카운트
         linkTo={`/chat/${localStorage.getItem("Id")}`}
       />
     </Container>


### PR DESCRIPTION
1) 아래 포커싱 현재 읽은 get 관련한 이슈  (확인 완료)

2) 오픈된 채팅방에 이벤트 발생시 (메세지 전송, 수신 등) 왼쪽 해당 채팅방과 실시간 (배포에 적용됨)

3) 채팅방 리스트 많아졌을 경우 스크롤바 (수정 완료)

4) 채팅방 리스트 간격 좁아짐 (수정 완료) 

5) 채팅방 각각 알림 적용

6) 안읽은 채팅방 전체 알림 표시 적용

7) 드롭다운 영역에도 반영