### PR TITLE
feat: 상품리스트에서 staleTime 삭제

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -59,6 +59,10 @@ function App() {
           element: <PostsList />,
         },
         {
+          path: "completed",
+          element: <PostsList />,
+        },
+        {
           path: "category/:category",
           element: <PostsList />,
         },

--- a/client/src/components/header/MenuItem.tsx
+++ b/client/src/components/header/MenuItem.tsx
@@ -138,6 +138,7 @@ const MenuItem = () => {
             categories="즉시 구매"
             linkTo={`/available?type=immediatelyBuy&page=1`}
           />
+          <Item key="거래 완료" categories="거래 완료" linkTo={`/completed?page=1`} />
         </ListBox>
       </ItemContainer>
     </>

--- a/client/src/components/productList/List.tsx
+++ b/client/src/components/productList/List.tsx
@@ -193,6 +193,14 @@ const List = (): JSX.Element => {
   const getData = async () => {
     const params = { page: page, size: ITEMS_PER_VIEW };
 
+    if (location.pathname === "/completed") {
+      const response = await axios.get(`/products/completed`, {
+        params: params,
+      });
+
+      return response.data;
+    }
+
     if (type) {
       const response = await axios.get(`/products/available`, {
         params: { ...params, type: type },
@@ -234,6 +242,10 @@ const List = (): JSX.Element => {
 
     if (type === "immediatelyBuy") {
       return "즉시 구매";
+    }
+
+    if (location.pathname === "/completed") {
+      return "거래 완료 상품";
     }
 
     if (path.includes("/all")) {

--- a/client/src/components/productList/List.tsx
+++ b/client/src/components/productList/List.tsx
@@ -219,7 +219,6 @@ const List = (): JSX.Element => {
       }
       setCurrentPage(page);
     },
-    staleTime: Infinity,
   });
 
   const isLogin = useRecoilValue(loginState);


### PR DESCRIPTION
staleTime을 Infinity로 적용해서 포커싱에서 벗어났다 다시 돌아왔을때 리페칭되는 현상을 막고자 했는데
이렇게 되니 브라우저 뒤로 가기를 이용해 리스트로 돌아갔을때 페칭이 안돼서 페이지네이션이 안보이는 문제가 있었습니다.
경매 상품 리스트를 포함하고 있어 최신상태를 유지하는것이 좋기 때문에 stateTime 을 Infinity로 유지할 필요성을 못느껴서 삭제했습니다.